### PR TITLE
fix link-customer-to-store-step

### DIFF
--- a/src/workflows/link-customer-to-store/steps/link-customer-to-store.ts
+++ b/src/workflows/link-customer-to-store/steps/link-customer-to-store.ts
@@ -13,9 +13,15 @@ export const linkCustomerToStoreStep = createStep(
   async (data: LinkCustomerToStoreStepInput, { container }) => {
     const link: Link = container.resolve(ContainerRegistrationKeys.LINK);
 
-    const currentStore = container.resolve("currentStore") as StoreDTO;
+    let currentStore: StoreDTO | undefined;
 
-    const store_id = data?.storeId || currentStore.id;
+    try {
+      currentStore = container.resolve("currentStore") as StoreDTO;
+    } catch (err) {
+      currentStore = undefined;
+    }
+
+    const store_id = data?.storeId || currentStore?.id;
 
     const linkArray = data.customerIds.map((customerId) =>
       link.create({


### PR DESCRIPTION
fix 

"Could not resolve 'currentStore'.\n\nResolution path: currentStore"

in  link-customer-to-store-step