### PR TITLE
fix: deduplicate product handles across stores

### DIFF
--- a/src/api/admin/products/middlewares.ts
+++ b/src/api/admin/products/middlewares.ts
@@ -21,7 +21,7 @@ export const adminProductsRoutesMiddlewares: MiddlewareRoute[] = [
   },
   {
     method: ["POST"],
-    matcher: "/admin/products",
+    matcher: "/admin/*",
     middlewares: [dedupProductHandle],
   },
 ];

--- a/src/api/admin/products/middlewares.ts
+++ b/src/api/admin/products/middlewares.ts
@@ -2,6 +2,7 @@ import { maybeApplyLinkFilter, MiddlewareRoute } from "@medusajs/framework";
 import { moveIdsToQueryFromFilterableFields } from "../../middlewares/move-ids-to-query-from-filterable-fields";
 import { addStoreIdToFilterableFields } from "../../middlewares/add-store-id-to-filterable-fields";
 import { productStoreAccessMiddleware } from "../../middlewares/product-store-access-middleware";
+import { dedupProductHandle } from "../../middlewares/dedup-product-handle";
 
 export const adminProductsRoutesMiddlewares: MiddlewareRoute[] = [
   {
@@ -17,5 +18,10 @@ export const adminProductsRoutesMiddlewares: MiddlewareRoute[] = [
       productStoreAccessMiddleware,
       moveIdsToQueryFromFilterableFields,
     ],
+  },
+  {
+    method: ["POST"],
+    matcher: "/admin/products",
+    middlewares: [dedupProductHandle],
   },
 ];

--- a/src/api/middlewares/dedup-product-handle.ts
+++ b/src/api/middlewares/dedup-product-handle.ts
@@ -74,7 +74,10 @@ export async function dedupProductHandle(
     while (await handleExists(productModule, candidate)) {
       suffix++
       if (suffix > MAX_ATTEMPTS) {
-        // Let Medusa's default handling take over
+        // Observability: learn how often we hit the cap in production.
+        console.warn(
+          `[dedup-product-handle] Reached ${MAX_ATTEMPTS}-attempt cap for "${storeSlug}-${productSlug}"; falling back to Medusa default handling.`,
+        )
         return next()
       }
       candidate = `${storeSlug}-${productSlug}-${suffix}`

--- a/src/api/middlewares/dedup-product-handle.ts
+++ b/src/api/middlewares/dedup-product-handle.ts
@@ -42,15 +42,16 @@ export async function dedupProductHandle(
       return next()
     }
 
-    // Resolve the vendor's store via the user→store link
-    let store = await resolveStoreFromUser(req)
+    // Use currentStore if already resolved by registerCurrentStore middleware
+    // (avoids a redundant DB query for dashboard/session auth)
+    let store = req.scope.resolve("currentStore", {
+      allowUnregistered: true,
+    }) as StoreDTO | undefined
 
-    // Fallback to currentStore from the container (for API-key auth
-    // where there is no loggedInUser)
+    // Fallback: query user→store link (needed for Bearer token auth
+    // where registerCurrentStore skips store resolution)
     if (!store?.name) {
-      store = req.scope.resolve("currentStore", {
-        allowUnregistered: true,
-      }) as StoreDTO | undefined
+      store = await resolveStoreFromUser(req)
     }
 
     if (!store?.name) {

--- a/src/api/middlewares/dedup-product-handle.ts
+++ b/src/api/middlewares/dedup-product-handle.ts
@@ -83,6 +83,13 @@ export async function dedupProductHandle(
       candidate = `${storeSlug}-${productSlug}-${suffix}`
     }
 
+    if (suffix > 1) {
+      // Observability: learn how many iterations dedup typically takes in production.
+      console.info(
+        `[dedup-product-handle] Resolved "${candidate}" after ${suffix - 1} attempt(s).`,
+      )
+    }
+
     body.handle = candidate
   } catch (error) {
     // If anything goes wrong (e.g. super-admin without a store),

--- a/src/api/middlewares/dedup-product-handle.ts
+++ b/src/api/middlewares/dedup-product-handle.ts
@@ -1,0 +1,101 @@
+import type {
+  AuthenticatedMedusaRequest,
+  MedusaNextFunction,
+  MedusaResponse,
+} from "@medusajs/framework/http"
+import { Modules } from "@medusajs/framework/utils"
+import { StoreDTO } from "@medusajs/framework/types"
+
+/**
+ * Middleware that prevents product handle collisions in a multi-vendor
+ * marketplace by prepending the vendor's store name to the product handle.
+ *
+ * Without this, two vendors creating a product with the same title
+ * (e.g. "Sample Product") would generate the same handle ("sample-product")
+ * and the second insert would fail on the unique constraint.
+ *
+ * Strategy:
+ *   1. Resolve the current store (already registered by registerCurrentStore).
+ *   2. Build a candidate handle: `{store-slug}-{product-slug}`.
+ *   3. If that candidate already exists (same vendor, duplicate title),
+ *      append an incrementing numeric suffix (`-2`, `-3`, …).
+ *   4. Inject the final handle into `req.body` so the downstream
+ *      createProductsWorkflow receives a guaranteed-unique value.
+ *
+ * Fixes: https://github.com/Tech-Labi/medusa2-marketplace-demo/issues/15
+ */
+export async function dedupProductHandle(
+  req: AuthenticatedMedusaRequest,
+  res: MedusaResponse,
+  next: MedusaNextFunction,
+) {
+  try {
+    const body = req.body as Record<string, unknown> | undefined
+    if (!body?.title) {
+      return next()
+    }
+
+    // currentStore is registered by registerCurrentStore middleware
+    const currentStore = req.scope.resolve("currentStore", {
+      allowUnregistered: true,
+    }) as StoreDTO | undefined
+
+    if (!currentStore?.name) {
+      return next()
+    }
+
+    // Build candidate handle: {store-slug}-{product-slug}
+    const storeSlug = toSlug(currentStore.name)
+    const productSlug = body.handle
+      ? toSlug(body.handle as string)
+      : toSlug(body.title as string)
+
+    let candidate = `${storeSlug}-${productSlug}`
+
+    // Ensure uniqueness — append suffix if the handle already exists
+    const productModule = req.scope.resolve(Modules.PRODUCT) as any
+
+    let suffix = 1
+    while (await handleExists(productModule, candidate)) {
+      suffix++
+      candidate = `${storeSlug}-${productSlug}-${suffix}`
+    }
+
+    body.handle = candidate
+  } catch (error) {
+    // If anything goes wrong (e.g. super-admin without a store),
+    // fall through and let Medusa use its default handle logic.
+    console.warn("[dedup-product-handle] Skipping:", (error as Error).message)
+  }
+
+  return next()
+}
+
+/**
+ * Convert a string to a URL-safe slug.
+ * Mirrors Medusa's internal toHandle() behaviour.
+ */
+function toSlug(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "") // strip accents
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-") // non-alphanum → hyphen
+    .replace(/^-+|-+$/g, "") // trim leading/trailing hyphens
+}
+
+/**
+ * Check whether a product with the given handle already exists
+ * (excluding soft-deleted rows, which Medusa filters out by default).
+ */
+async function handleExists(
+  productModule: any,
+  handle: string,
+): Promise<boolean> {
+  const [products] = await productModule.listAndCountProducts(
+    { handle },
+    { take: 1, select: ["id"] },
+  )
+  return products.length > 0
+}

--- a/src/api/middlewares/dedup-product-handle.ts
+++ b/src/api/middlewares/dedup-product-handle.ts
@@ -15,8 +15,9 @@ import { StoreDTO, UserDTO } from "@medusajs/framework/types"
  * and the second insert would fail on the unique constraint.
  *
  * Strategy:
- *   1. Resolve the current store — from container if available, otherwise
- *      fall back to querying the user→store link.
+ *   1. Resolve the vendor's store via the user→store link. Falls back
+ *      to the container's `currentStore` for API-key auth where there
+ *      is no `loggedInUser`.
  *   2. Build a candidate handle: `{store-slug}-{product-slug}`.
  *   3. If that candidate already exists (same vendor, duplicate title),
  *      append an incrementing numeric suffix (`-2`, `-3`, …).
@@ -41,15 +42,15 @@ export async function dedupProductHandle(
       return next()
     }
 
-    // Try currentStore from registerCurrentStore middleware first
-    let store = req.scope.resolve("currentStore", {
-      allowUnregistered: true,
-    }) as StoreDTO | undefined
+    // Resolve the vendor's store via the user→store link
+    let store = await resolveStoreFromUser(req)
 
-    // Fallback: resolve store from user→store link (covers Bearer token auth
-    // where registerCurrentStore skips store resolution)
+    // Fallback to currentStore from the container (for API-key auth
+    // where there is no loggedInUser)
     if (!store?.name) {
-      store = await resolveStoreFromUser(req)
+      store = req.scope.resolve("currentStore", {
+        allowUnregistered: true,
+      }) as StoreDTO | undefined
     }
 
     if (!store?.name) {

--- a/src/api/middlewares/dedup-product-handle.ts
+++ b/src/api/middlewares/dedup-product-handle.ts
@@ -68,9 +68,14 @@ export async function dedupProductHandle(
     // Ensure uniqueness — append suffix if the handle already exists
     const productModule = req.scope.resolve(Modules.PRODUCT) as any
 
+    const MAX_ATTEMPTS = 100
     let suffix = 1
     while (await handleExists(productModule, candidate)) {
       suffix++
+      if (suffix > MAX_ATTEMPTS) {
+        // Let Medusa's default handling take over
+        return next()
+      }
       candidate = `${storeSlug}-${productSlug}-${suffix}`
     }
 

--- a/src/api/middlewares/dedup-product-handle.ts
+++ b/src/api/middlewares/dedup-product-handle.ts
@@ -3,7 +3,7 @@ import type {
   MedusaNextFunction,
   MedusaResponse,
 } from "@medusajs/framework/http"
-import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { ContainerRegistrationKeys, Modules, toHandle } from "@medusajs/framework/utils"
 import { StoreDTO, UserDTO } from "@medusajs/framework/types"
 
 /**
@@ -58,10 +58,10 @@ export async function dedupProductHandle(
     }
 
     // Build candidate handle: {store-slug}-{product-slug}
-    const storeSlug = toSlug(store.name)
+    const storeSlug = toHandle(store.name)
     const productSlug = body.handle
-      ? toSlug(body.handle as string)
-      : toSlug(body.title as string)
+      ? toHandle(body.handle as string)
+      : toHandle(body.title as string)
 
     let candidate = `${storeSlug}-${productSlug}`
 
@@ -87,20 +87,6 @@ export async function dedupProductHandle(
   }
 
   return next()
-}
-
-/**
- * Convert a string to a URL-safe slug.
- * Mirrors Medusa's internal toHandle() behaviour.
- */
-function toSlug(value: string): string {
-  return value
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "") // strip accents
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, "-") // non-alphanum → hyphen
-    .replace(/^-+|-+$/g, "") // trim leading/trailing hyphens
 }
 
 /**

--- a/src/api/middlewares/dedup-product-handle.ts
+++ b/src/api/middlewares/dedup-product-handle.ts
@@ -3,8 +3,8 @@ import type {
   MedusaNextFunction,
   MedusaResponse,
 } from "@medusajs/framework/http"
-import { Modules } from "@medusajs/framework/utils"
-import { StoreDTO } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+import { StoreDTO, UserDTO } from "@medusajs/framework/types"
 
 /**
  * Middleware that prevents product handle collisions in a multi-vendor
@@ -15,7 +15,8 @@ import { StoreDTO } from "@medusajs/framework/types"
  * and the second insert would fail on the unique constraint.
  *
  * Strategy:
- *   1. Resolve the current store (already registered by registerCurrentStore).
+ *   1. Resolve the current store — from container if available, otherwise
+ *      fall back to querying the user→store link.
  *   2. Build a candidate handle: `{store-slug}-{product-slug}`.
  *   3. If that candidate already exists (same vendor, duplicate title),
  *      append an incrementing numeric suffix (`-2`, `-3`, …).
@@ -30,22 +31,33 @@ export async function dedupProductHandle(
   next: MedusaNextFunction,
 ) {
   try {
+    // Only act on product creation requests
+    if (!req.path.endsWith("/admin/products")) {
+      return next()
+    }
+
     const body = req.body as Record<string, unknown> | undefined
     if (!body?.title) {
       return next()
     }
 
-    // currentStore is registered by registerCurrentStore middleware
-    const currentStore = req.scope.resolve("currentStore", {
+    // Try currentStore from registerCurrentStore middleware first
+    let store = req.scope.resolve("currentStore", {
       allowUnregistered: true,
     }) as StoreDTO | undefined
 
-    if (!currentStore?.name) {
+    // Fallback: resolve store from user→store link (covers Bearer token auth
+    // where registerCurrentStore skips store resolution)
+    if (!store?.name) {
+      store = await resolveStoreFromUser(req)
+    }
+
+    if (!store?.name) {
       return next()
     }
 
     // Build candidate handle: {store-slug}-{product-slug}
-    const storeSlug = toSlug(currentStore.name)
+    const storeSlug = toSlug(store.name)
     const productSlug = body.handle
       ? toSlug(body.handle as string)
       : toSlug(body.title as string)
@@ -98,4 +110,29 @@ async function handleExists(
     { take: 1, select: ["id"] },
   )
   return products.length > 0
+}
+
+/**
+ * Resolve the vendor's store by querying the user→store link.
+ * Covers the case where registerCurrentStore doesn't register a store
+ * (e.g. Bearer token auth with actor_type "user").
+ */
+async function resolveStoreFromUser(
+  req: AuthenticatedMedusaRequest,
+): Promise<StoreDTO | undefined> {
+  const loggedInUser = req.scope.resolve("loggedInUser", {
+    allowUnregistered: true,
+  }) as UserDTO | undefined
+
+  if (!loggedInUser?.id) return undefined
+
+  const query = req.scope.resolve(ContainerRegistrationKeys.QUERY) as any
+
+  const { data: userStoreLinks } = await query.graph({
+    entity: "user_store",
+    fields: ["store.*"],
+    filters: { user_id: loggedInUser.id },
+  })
+
+  return userStoreLinks?.[0]?.store as StoreDTO | undefined
 }


### PR DESCRIPTION
## Summary

- Fixes product handle collisions when multiple vendors create products with the same title (e.g. two stores both creating "Sample Product")
- Adds a middleware on `POST /admin/products` that prepends the vendor's store slug to the product handle, ensuring global uniqueness
- Appends a numeric suffix (`-2`, `-3`, …) if the prefixed handle still collides (same vendor, duplicate title)

Fixes Tech-Labi/medusa2-marketplace-demo#15

### How it works

The `dedupProductHandle` middleware runs **before** `createProductsWorkflow`, intercepting `req.body` to inject a unique handle. It leverages the `currentStore` already registered by `registerCurrentStore`.

| Store | Product title | Generated handle |
|-------|--------------|-----------------|
| Store A | Sample Product | `store-a-sample-product` |
| Store B | Sample Product | `store-b-sample-product` |
| Store A | Sample Product (2nd) | `store-a-sample-product-2` |

### Why a middleware?

The `productsCreated` hook fires after the DB insert — if the handle collides, the insert fails with a `IDX_product_handle_unique` constraint error before the hook ever runs. The middleware sets a safe handle before the workflow executes.

### Files changed

- `src/api/middlewares/dedup-product-handle.ts` — new middleware with dedup logic
- `src/api/admin/products/middlewares.ts` — registers the middleware on `POST /admin/products`

## Test plan

- [ ] Create Store A and Store B with different vendor users
- [ ] In Store A, create a product "Sample Product" → handle should be `store-a-sample-product`
- [ ] In Store B, create a product "Sample Product" → handle should be `store-b-sample-product` (no constraint error)
- [ ] In Store A, create another "Sample Product" → handle should be `store-a-sample-product-2`
- [ ] Verify accented titles are handled correctly (e.g. "Café Doré" → `store-a-cafe-dore`)
- [ ] Verify super admin (no store context) falls through to default Medusa behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)